### PR TITLE
added inputs to allow indication of operational requirements documented with ISSO

### DIFF
--- a/controls/SV-257792.rb
+++ b/controls/SV-257792.rb
@@ -44,13 +44,21 @@ GRUB_CMDLINE_LINUX="vsyscall=none"'
     !virtualization.system.eql?('docker')
   }
 
-  grub_stdout = command('grubby --info=ALL').stdout
-  setting = /vsyscall\s*=\s*none/
+  if input('vsyscall_required')
+    impact 0.0
+    describe 'N/A' do
+      skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
+    end
+  else
 
-  describe 'GRUB config' do
-    it 'should disable vsyscall' do
-      expect(parse_config(grub_stdout)['args']).to match(setting), 'Current GRUB configuration does not disable this setting'
-      expect(parse_config_file('/etc/default/grub')['GRUB_CMDLINE_LINUX']).to match(setting), 'Setting not configured to persist between kernel updates'
+    grub_stdout = command('grubby --info=ALL').stdout
+    setting = /vsyscall\s*=\s*none/
+
+    describe 'GRUB config' do
+      it 'should disable vsyscall' do
+        expect(parse_config(grub_stdout)['args']).to match(setting), 'Current GRUB configuration does not disable this setting'
+        expect(parse_config_file('/etc/default/grub')['GRUB_CMDLINE_LINUX']).to match(setting), 'Setting not configured to persist between kernel updates'
+      end
     end
   end
 end

--- a/controls/SV-257803.rb
+++ b/controls/SV-257803.rb
@@ -42,26 +42,34 @@ $ sudo sysctl --system'
     !virtualization.system.eql?('docker')
   }
 
-  parameter = 'kernel.core_pattern'
-  value = 1
-  regexp = /^\s*#{parameter}\s*=\s*#{value}\s*$/
-
-  describe kernel_parameter(parameter) do
-    its('value') { should eq value }
-  end
-
-  search_results = command("/usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F #{parameter}").stdout.strip.split("\n")
-
-  correct_result = search_results.any? { |line| line.match(regexp) }
-  incorrect_results = search_results.map(&:strip).reject { |line| line.match(regexp) }
-
-  describe 'Kernel config files' do
-    it "should configure '#{parameter}'" do
-      expect(correct_result).to eq(true), 'No config file was found that correctly sets this action'
+  if input('storing_core_dumps_required')
+    impact 0.0
+    describe 'N/A' do
+      skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
     end
-    unless incorrect_results.nil?
-      it 'should not have incorrect or conflicting setting(s) in the config files' do
-        expect(incorrect_results).to be_empty, "Incorrect or conflicting setting(s) found:\n\t- #{incorrect_results.join("\n\t- ")}"
+  else
+
+    parameter = 'kernel.core_pattern'
+    value = 1
+    regexp = /^\s*#{parameter}\s*=\s*#{value}\s*$/
+
+    describe kernel_parameter(parameter) do
+      its('value') { should eq value }
+    end
+
+    search_results = command("/usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F #{parameter}").stdout.strip.split("\n")
+
+    correct_result = search_results.any? { |line| line.match(regexp) }
+    incorrect_results = search_results.map(&:strip).reject { |line| line.match(regexp) }
+
+    describe 'Kernel config files' do
+      it "should configure '#{parameter}'" do
+        expect(correct_result).to eq(true), 'No config file was found that correctly sets this action'
+      end
+      unless incorrect_results.nil?
+        it 'should not have incorrect or conflicting setting(s) in the config files' do
+          expect(incorrect_results).to be_empty, "Incorrect or conflicting setting(s) found:\n\t- #{incorrect_results.join("\n\t- ")}"
+        end
       end
     end
   end

--- a/controls/SV-257804.rb
+++ b/controls/SV-257804.rb
@@ -28,8 +28,16 @@ blacklist atm'
     !virtualization.system.eql?('docker')
   }
 
-  describe kernel_module('atm') do
-    it { should be_disabled }
-    it { should be_blacklisted }
+  if input('atm_required')
+    impact 0.0
+    describe 'N/A' do
+      skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
+    end
+  else
+
+    describe kernel_module('atm') do
+      it { should be_disabled }
+      it { should be_blacklisted }
+    end
   end
 end

--- a/controls/SV-257805.rb
+++ b/controls/SV-257805.rb
@@ -28,8 +28,16 @@ blacklist can'
     !virtualization.system.eql?('docker')
   }
 
-  describe kernel_module('can') do
-    it { should be_disabled }
-    it { should be_blacklisted }
+  if input('can_required')
+    impact 0.0
+    describe 'N/A' do
+      skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
+    end
+  else
+
+    describe kernel_module('can') do
+      it { should be_disabled }
+      it { should be_blacklisted }
+    end
   end
 end

--- a/controls/SV-257806.rb
+++ b/controls/SV-257806.rb
@@ -28,8 +28,16 @@ blacklist firewire-core'
     !virtualization.system.eql?('docker')
   }
 
-  describe kernel_module('firewire_core') do
-    it { should be_disabled }
-    it { should be_blacklisted }
+  if input('firewire_required')
+    impact 0.0
+    describe 'N/A' do
+      skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
+    end
+  else
+
+    describe kernel_module('firewire_core') do
+      it { should be_disabled }
+      it { should be_blacklisted }
+    end
   end
 end

--- a/controls/SV-257807.rb
+++ b/controls/SV-257807.rb
@@ -38,8 +38,17 @@ blacklist sctp'
   only_if('This control is Not Applicable to containers', impact: 0.0) {
     !virtualization.system.eql?('docker')
   }
-  describe kernel_module('sctp') do
-    it { should be_disabled }
-    it { should be_blacklisted }
+
+  if input('sctp_required')
+    impact 0.0
+    describe 'N/A' do
+      skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
+    end
+  else
+
+    describe kernel_module('sctp') do
+      it { should be_disabled }
+      it { should be_blacklisted }
+    end
   end
 end

--- a/controls/SV-257808.rb
+++ b/controls/SV-257808.rb
@@ -32,8 +32,16 @@ blacklist tipc'
     !virtualization.system.eql?('docker')
   }
 
-  describe kernel_module('tipc') do
-    it { should be_disabled }
-    it { should be_blacklisted }
+  if input('tipc_required')
+    impact 0.0
+    describe 'N/A' do
+      skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
+    end
+  else
+
+    describe kernel_module('tipc') do
+      it { should be_disabled }
+      it { should be_blacklisted }
+    end
   end
 end

--- a/controls/SV-257812.rb
+++ b/controls/SV-257812.rb
@@ -32,7 +32,15 @@ ProcessSizeMax=0'
     !virtualization.system.eql?('docker')
   }
 
-  describe parse_config_file('/etc/systemd/coredump.conf') do
-    its('Coredump.ProcessSizeMax') { should cmp '0' }
+  if input('core_dumps_required')
+    impact 0.0
+    describe 'N/A' do
+      skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
+    end
+  else
+
+    describe parse_config_file('/etc/systemd/coredump.conf') do
+      its('Coredump.ProcessSizeMax') { should cmp '0' }
+    end
   end
 end

--- a/controls/SV-257813.rb
+++ b/controls/SV-257813.rb
@@ -30,7 +30,15 @@ Storage=none'
     !virtualization.system.eql?('docker')
   }
 
-  describe parse_config_file('/etc/systemd/coredump.conf') do
-    its('Coredump.Storage') { should cmp 'none' }
+  if input('storing_core_dumps_required')
+    impact 0.0
+    describe 'N/A' do
+      skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
+    end
+  else
+
+    describe parse_config_file('/etc/systemd/coredump.conf') do
+      its('Coredump.Storage') { should cmp 'none' }
+    end
   end
 end

--- a/controls/SV-257814.rb
+++ b/controls/SV-257814.rb
@@ -32,27 +32,35 @@ Add the following line to the top of the /etc/security/limits.conf or in a singl
     !virtualization.system.eql?('docker')
   }
 
-  setting = 'core'
-  expected_value = input('core_dump_expected_value')
-
-  limits_files = command('ls /etc/security/limits.d/*.conf').stdout.strip.split
-  limits_files.append('/etc/security/limits.conf')
-
-  # make sure that at least one limits.conf file has the correct setting
-  globally_set = limits_files.any? { |lf| !limits_conf(lf).read_params['*'].nil? && limits_conf(lf).read_params['*'].include?(['hard', setting.to_s, expected_value.to_s]) }
-
-  # make sure that no limits.conf file has a value that contradicts the global set
-  failing_files = limits_files.select { |lf|
-    limits_conf(lf).read_params.values.flatten(1).any? { |l|
-      l[1].eql?(setting) && !l[2].to_i.eql?(expected_value)
-    }
-  }
-  describe 'Limits files' do
-    it 'should disallow core dumps by default' do
-      expect(globally_set).to eq(true), "No correct global ('*') setting found"
+  if input('core_dumps_required')
+    impact 0.0
+    describe 'N/A' do
+      skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
     end
-    it 'should not have any conflicting settings' do
-      expect(failing_files).to be_empty, "Files with incorrect '#{setting}' settings:\n\t- #{failing_files.join("\n\t- ")}"
+  else
+
+    setting = 'core'
+    expected_value = input('core_dump_expected_value')
+
+    limits_files = command('ls /etc/security/limits.d/*.conf').stdout.strip.split
+    limits_files.append('/etc/security/limits.conf')
+
+    # make sure that at least one limits.conf file has the correct setting
+    globally_set = limits_files.any? { |lf| !limits_conf(lf).read_params['*'].nil? && limits_conf(lf).read_params['*'].include?(['hard', setting.to_s, expected_value.to_s]) }
+
+    # make sure that no limits.conf file has a value that contradicts the global set
+    failing_files = limits_files.select { |lf|
+      limits_conf(lf).read_params.values.flatten(1).any? { |l|
+        l[1].eql?(setting) && !l[2].to_i.eql?(expected_value)
+      }
+    }
+    describe 'Limits files' do
+      it 'should disallow core dumps by default' do
+        expect(globally_set).to eq(true), "No correct global ('*') setting found"
+      end
+      it 'should not have any conflicting settings' do
+        expect(failing_files).to be_empty, "Files with incorrect '#{setting}' settings:\n\t- #{failing_files.join("\n\t- ")}"
+      end
     end
   end
 end

--- a/controls/SV-257815.rb
+++ b/controls/SV-257815.rb
@@ -36,14 +36,22 @@ $ sudo systemctl daemon-reload'
     !virtualization.system.eql?('docker')
   }
 
-  s = systemd_service('systemd-coredump.socket')
-
-  describe.one do
-    describe s do
-      its('params.LoadState') { should eq 'masked' }
+  if input('core_dumps_required')
+    impact 0.0
+    describe 'N/A' do
+      skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
     end
-    describe s do
-      its('params.LoadState') { should eq 'not-found' }
+  else
+
+    s = systemd_service('systemd-coredump.socket')
+
+    describe.one do
+      describe s do
+        its('params.LoadState') { should eq 'masked' }
+      end
+      describe s do
+        its('params.LoadState') { should eq 'not-found' }
+      end
     end
   end
 end

--- a/controls/SV-257836.rb
+++ b/controls/SV-257836.rb
@@ -27,7 +27,13 @@ $ sudo dnf remove quagga'
   tag nist: ['CM-6 b']
   tag 'host', 'container'
 
-  describe package('quagga') do
-    it { should_not be_installed }
+  if input('quagga_required')
+    describe package('quagga') do
+      it { should be_installed }
+    end
+  else
+    describe package('quagga') do
+      it { should_not be_installed }
+    end
   end
 end

--- a/controls/SV-257880.rb
+++ b/controls/SV-257880.rb
@@ -38,8 +38,17 @@ blacklist cramfs'
   only_if('This control is Not Applicable to containers', impact: 0.0) {
     !virtualization.system.eql?('docker')
   }
-  describe kernel_module('cramfs') do
-    it { should be_disabled }
-    it { should be_blacklisted }
+
+  if input('cramfs_required')
+    impact 0.0
+    describe 'N/A' do
+      skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
+    end
+  else
+
+    describe kernel_module('cramfs') do
+      it { should be_disabled }
+      it { should be_blacklisted }
+    end
   end
 end

--- a/controls/SV-257971.rb
+++ b/controls/SV-257971.rb
@@ -45,26 +45,34 @@ $ sudo sysctl --system'
     !virtualization.system.eql?('docker')
   }
 
-  parameter = 'net.ipv6.conf.all.accept_ra'
-  value = 0
-  regexp = /^\s*#{parameter}\s*=\s*#{value}\s*$/
-
-  describe kernel_parameter(parameter) do
-    its('value') { should eq value }
-  end
-
-  search_results = command("/usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F #{parameter}").stdout.strip.split("\n")
-
-  correct_result = search_results.any? { |line| line.match(regexp) }
-  incorrect_results = search_results.map(&:strip).reject { |line| line.match(regexp) }
-
-  describe 'Kernel config files' do
-    it "should configure '#{parameter}'" do
-      expect(correct_result).to eq(true), 'No config file was found that correctly sets this action'
+  if input('accept_ra_required')
+    impact 0.0
+    describe 'N/A' do
+      skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
     end
-    unless incorrect_results.nil?
-      it 'should not have incorrect or conflicting setting(s) in the config files' do
-        expect(incorrect_results).to be_empty, "Incorrect or conflicting setting(s) found:\n\t- #{incorrect_results.join("\n\t- ")}"
+  else
+
+    parameter = 'net.ipv6.conf.all.accept_ra'
+    value = 0
+    regexp = /^\s*#{parameter}\s*=\s*#{value}\s*$/
+
+    describe kernel_parameter(parameter) do
+      its('value') { should eq value }
+    end
+
+    search_results = command("/usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F #{parameter}").stdout.strip.split("\n")
+
+    correct_result = search_results.any? { |line| line.match(regexp) }
+    incorrect_results = search_results.map(&:strip).reject { |line| line.match(regexp) }
+
+    describe 'Kernel config files' do
+      it "should configure '#{parameter}'" do
+        expect(correct_result).to eq(true), 'No config file was found that correctly sets this action'
+      end
+      unless incorrect_results.nil?
+        it 'should not have incorrect or conflicting setting(s) in the config files' do
+          expect(incorrect_results).to be_empty, "Incorrect or conflicting setting(s) found:\n\t- #{incorrect_results.join("\n\t- ")}"
+        end
       end
     end
   end

--- a/controls/SV-257974.rb
+++ b/controls/SV-257974.rb
@@ -45,26 +45,34 @@ $ sudo sysctl --system'
     !virtualization.system.eql?('docker')
   }
 
-  parameter = 'net.ipv6.conf.all.forwarding'
-  value = 0
-  regexp = /^\s*#{parameter}\s*=\s*#{value}\s*$/
-
-  describe kernel_parameter(parameter) do
-    its('value') { should eq value }
-  end
-
-  search_results = command("/usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F #{parameter}").stdout.strip.split("\n")
-
-  correct_result = search_results.any? { |line| line.match(regexp) }
-  incorrect_results = search_results.map(&:strip).reject { |line| line.match(regexp) }
-
-  describe 'Kernel config files' do
-    it "should configure '#{parameter}'" do
-      expect(correct_result).to eq(true), 'No config file was found that correctly sets this action'
+  if input('forwarding')
+    impact 0.0
+    describe 'N/A' do
+      skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
     end
-    unless incorrect_results.nil?
-      it 'should not have incorrect or conflicting setting(s) in the config files' do
-        expect(incorrect_results).to be_empty, "Incorrect or conflicting setting(s) found:\n\t- #{incorrect_results.join("\n\t- ")}"
+  else
+
+    parameter = 'net.ipv6.conf.all.forwarding'
+    value = 0
+    regexp = /^\s*#{parameter}\s*=\s*#{value}\s*$/
+
+    describe kernel_parameter(parameter) do
+      its('value') { should eq value }
+    end
+
+    search_results = command("/usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F #{parameter}").stdout.strip.split("\n")
+
+    correct_result = search_results.any? { |line| line.match(regexp) }
+    incorrect_results = search_results.map(&:strip).reject { |line| line.match(regexp) }
+
+    describe 'Kernel config files' do
+      it "should configure '#{parameter}'" do
+        expect(correct_result).to eq(true), 'No config file was found that correctly sets this action'
+      end
+      unless incorrect_results.nil?
+        it 'should not have incorrect or conflicting setting(s) in the config files' do
+          expect(incorrect_results).to be_empty, "Incorrect or conflicting setting(s) found:\n\t- #{incorrect_results.join("\n\t- ")}"
+        end
       end
     end
   end

--- a/controls/SV-257975.rb
+++ b/controls/SV-257975.rb
@@ -45,26 +45,34 @@ $ sudo sysctl --system'
     !virtualization.system.eql?('docker')
   }
 
-  parameter = 'net.ipv6.conf.default.accept_ra'
-  value = 0
-  regexp = /^\s*#{parameter}\s*=\s*#{value}\s*$/
-
-  describe kernel_parameter(parameter) do
-    its('value') { should eq value }
-  end
-
-  search_results = command("/usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F #{parameter}").stdout.strip.split("\n")
-
-  correct_result = search_results.any? { |line| line.match(regexp) }
-  incorrect_results = search_results.map(&:strip).reject { |line| line.match(regexp) }
-
-  describe 'Kernel config files' do
-    it "should configure '#{parameter}'" do
-      expect(correct_result).to eq(true), 'No config file was found that correctly sets this action'
+  if input('accept_ra_required')
+    impact 0.0
+    describe 'N/A' do
+      skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
     end
-    unless incorrect_results.nil?
-      it 'should not have incorrect or conflicting setting(s) in the config files' do
-        expect(incorrect_results).to be_empty, "Incorrect or conflicting setting(s) found:\n\t- #{incorrect_results.join("\n\t- ")}"
+  else
+
+    parameter = 'net.ipv6.conf.default.accept_ra'
+    value = 0
+    regexp = /^\s*#{parameter}\s*=\s*#{value}\s*$/
+
+    describe kernel_parameter(parameter) do
+      its('value') { should eq value }
+    end
+
+    search_results = command("/usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F #{parameter}").stdout.strip.split("\n")
+
+    correct_result = search_results.any? { |line| line.match(regexp) }
+    incorrect_results = search_results.map(&:strip).reject { |line| line.match(regexp) }
+
+    describe 'Kernel config files' do
+      it "should configure '#{parameter}'" do
+        expect(correct_result).to eq(true), 'No config file was found that correctly sets this action'
+      end
+      unless incorrect_results.nil?
+        it 'should not have incorrect or conflicting setting(s) in the config files' do
+          expect(incorrect_results).to be_empty, "Incorrect or conflicting setting(s) found:\n\t- #{incorrect_results.join("\n\t- ")}"
+        end
       end
     end
   end

--- a/controls/SV-258007.rb
+++ b/controls/SV-258007.rb
@@ -34,7 +34,15 @@ $ sudo systemctl restart sshd.service'
     !(virtualization.system.eql?('docker') && !file('/etc/ssh/sshd_config').exist?)
   }
 
-  describe sshd_config do
-    its('X11Forwarding') { should cmp 'no' }
+  if input('x11_forwarding_required')
+    impact 0.0
+    describe 'N/A' do
+      skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
+    end
+  else
+
+    describe sshd_config do
+      its('X11Forwarding') { should cmp 'no' }
+    end
   end
 end

--- a/controls/SV-258014.rb
+++ b/controls/SV-258014.rb
@@ -50,6 +50,11 @@ $ sudo dconf update'
     describe 'The system does not have a GUI Desktop is installed, this control is Not Applicable' do
       skip 'A GUI desktop is not installed, this control is Not Applicable.'
     end
+  elsif input('gui_automount_required')
+    impact 0.0
+    describe 'N/A' do
+      skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
+    end
   else
     describe command('gsettings get org.gnome.desktop.media-handling automount-open') do
       its('stdout.strip') { should cmp 'false' }

--- a/controls/SV-258016.rb
+++ b/controls/SV-258016.rb
@@ -40,16 +40,24 @@ $ sudo dconf update'
     !virtualization.system.eql?('docker')
   }
 
-  no_gui = command('ls /usr/share/xsessions/*').stderr.match?(/No such file or directory/)
-
-  if no_gui
+  if input('gui_autorun_required')
     impact 0.0
-    describe 'The system does not have a GUI Desktop is installed, this control is Not Applicable' do
-      skip 'A GUI desktop is not installed, this control is Not Applicable.'
+    describe 'N/A' do
+      skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
     end
   else
-    describe command('gsettings get org.gnome.desktop.media-handling autorun-never') do
-      its('stdout.strip') { should cmp 'true' }
+
+    no_gui = command('ls /usr/share/xsessions/*').stderr.match?(/No such file or directory/)
+
+    if no_gui
+      impact 0.0
+      describe 'The system does not have a GUI Desktop is installed, this control is Not Applicable' do
+        skip 'A GUI desktop is not installed, this control is Not Applicable.'
+      end
+    else
+      describe command('gsettings get org.gnome.desktop.media-handling autorun-never') do
+        its('stdout.strip') { should cmp 'true' }
+      end
     end
   end
 end

--- a/controls/SV-258039.rb
+++ b/controls/SV-258039.rb
@@ -33,9 +33,17 @@ Reboot the system for the settings to take effect.'
   }
 
   if input('bluetooth_installed')
-    describe kernel_module('bluetooth') do
-      it { should be_disabled }
-      it { should be_blacklisted }
+    if input('bluetooth_required')
+      impact 0.0
+      describe 'N/A' do
+        skip "Profile inputs indicate that this parameter's setting is a documented operational requirement"
+      end
+    else
+
+      describe kernel_module('bluetooth') do
+        it { should be_disabled }
+        it { should be_blacklisted }
+      end
     end
   else
     impact 0.0

--- a/inspec.yml
+++ b/inspec.yml
@@ -817,17 +817,21 @@ inputs:
     type: Boolean
     value: false
 
-    # SV-230560
   # SV-257833
   - name: iprutils_required
     description: Set to true if there is a documented requirement for the target system to use iprutils
     type: Boolean
     value: false
   
-    # SV-230561
   # SV-257834
   - name: tuned_required
     description: Set to true if there is a documented requirement for the target system to use tuned
+    type: Boolean
+    value: false
+
+  # SV-257836
+  - name: quagga_required
+    description: Set to true if there is a documented requirement for the target system to use quagga
     type: Boolean
     value: false
 
@@ -1011,8 +1015,92 @@ inputs:
     type: Boolean
     value: false
 
-  # SV-257970
+  # SV-257970, SV-257974
   - name: forwarding
     description: Set to true if there is a requirement for this system to be able forward packets that is documented with the ISSO
+    type: Boolean
+    value: false
+
+  # SV-257792
+  - name: vsyscall_required
+    description: Set to true if there is a requirement for this system to allow virtual system calls that is documented with the ISSO
+    type: Boolean
+    value: false
+
+  # SV-257803
+  - name: storing_core_dumps_required
+    description: Set to true if there is a requirement for this system to store core dumps that is documented with the ISSO
+    type: Boolean
+    value: false
+
+  # SV-257812
+  - name: core_dumps_required
+    description: Set to true if there is a requirement for this system to enable core dumps that is documented with the ISSO
+    type: Boolean
+    value: false
+
+  # SV-257804
+  - name: atm_required
+    description: Set to true if there is a requirement for this system to enable the Asynchronous Transfer Mode kernel module that is documented with the ISSO
+    type: Boolean
+    value: false
+
+  # SV-257805
+  - name: can_required
+    description: Set to true if there is a requirement for this system to enable the Controller Area Network kernel module that is documented with the ISSO
+    type: Boolean
+    value: false
+
+  # SV-257806
+  - name: firewire_required
+    description: Set to true if there is a requirement for this system to enable the FireWire kernel module that is documented with the ISSO
+    type: Boolean
+    value: false
+
+  # SV-257807
+  - name: sctp_required
+    description: Set to true if there is a requirement for this system to enable the Stream Control Transmission Protocol (SCTP) kernel module that is documented with the ISSO
+    type: Boolean
+    value: false
+
+  # SV-257808
+  - name: tipc_required
+    description: Set to true if there is a requirement for this system to enable the Transparent Inter Process Communication (TIPC) kernel module that is documented with the ISSO
+    type: Boolean
+    value: false
+
+  # SV-257880
+  - name: cramfs_required
+    description: Set to true if there is a requirement for this system to enable the Compressed ROM/RAM file system (cramfs) that is documented with the ISSO
+    type: Boolean
+    value: false
+
+  # SV-258039
+  - name: bluetooth_required
+    description: Set to true if there is a requirement for this system to enable Bluetooth that is documented with the ISSO
+    type: Boolean
+    value: false
+
+  # SV-257971, SV-257975
+  - name: accept_ra_required
+    description: Set to true if there is a requirement for this system to accept router advertisements that is documented with the ISSO
+    type: Boolean
+    value: false
+
+  # SV-258007
+  - name: x11_forwarding_required
+    description: Set to true if there is a requirement for this system to enable X11 forwarding that is documented with the ISSO
+    type: Boolean
+    value: false
+
+  # SV-258014
+  - name: gui_automount_required
+    description: Set to true if there is a requirement for this system to enable graphical user interface automount function that is documented with the ISSO
+    type: Boolean
+    value: false
+
+  # SV-258014
+  - name: gui_autorun_required
+    description: Set to true if there is a requirement for this system to enable graphical user interface autorun function that is documented with the ISSO
     type: Boolean
     value: false


### PR DESCRIPTION
Fix to #39. Modeled these changes off of previous cases where ISSO waivers were mentioned such as [SV-257970](https://github.com/mitre/redhat-enterprise-linux-9-stig-baseline/blob/751185cd087f5af8c4d6047d08152d59f9d944c7/controls/SV-257970.rb#L48) and [SV-257968](https://github.com/mitre/redhat-enterprise-linux-9-stig-baseline/blob/751185cd087f5af8c4d6047d08152d59f9d944c7/controls/SV-257968.rb#L48). Added inputs where inputs weren't provided already. I avoided doing [SV-257951](https://github.com/mitre/redhat-enterprise-linux-9-stig-baseline/blob/751185cd087f5af8c4d6047d08152d59f9d944c7/controls/SV-257951.rb) and [SV-258040](https://github.com/mitre/redhat-enterprise-linux-9-stig-baseline/blob/751185cd087f5af8c4d6047d08152d59f9d944c7/controls/SV-258040.rb), because they did not fit the pattern with all the other changes and are a bit more complex. These seem to require a list of approved exemptions rather than just a `is_setting_or_module_an_operational_requirement` type of implementation. 