### PR TITLE
added inputs to allow alternate ini file locations and permission exemptions

### DIFF
--- a/inspec.yml
+++ b/inspec.yml
@@ -129,6 +129,18 @@ inputs:
     type: String
     value: '0740'
 
+  # SV-257889
+  - name: exempt_ini_files
+    description: List of initialization files that are exempt from permissions checks
+    type: Array
+    value: [] 
+    
+  # SV-257889
+  - name: alternate_ini_file_dirs
+    description: List of directories, other than a user's homedir, to search for initialization files
+    type: Array
+    value: []
+
   # SV-258157
   - name: alert_method
     description: 'The method used to provide real-time information to the ISSO or AO'


### PR DESCRIPTION
Fix to #42, although this does not address [SV-258050](https://github.com/mitre/redhat-enterprise-linux-9-stig-baseline/blob/751185cd087f5af8c4d6047d08152d59f9d944c7/controls/SV-258050.rb#L37) and [258062](https://github.com/mitre/redhat-enterprise-linux-9-stig-baseline/blob/751185cd087f5af8c4d6047d08152d59f9d944c7/controls/SV-258062.rb#L47) which seem to operate under the assumption that initialization files will only be found in the home directory. 