### PR TITLE
Replaced `squish` (rails method) to `strip` to fix a profile error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Redhat Enterprise Linux 9.X Security Technical Implementation Guide (RHEL9.x STIG) InSpec Profile can help programs automate their compliance checks of RedHat Enterprise Linux 9.x System to Department of Defense (DoD) requirements.
 
-- Profile Version: `1.2.0`
+- Profile Version: `1.2.2`
 - RedHat Enterprise Linux 9 Security Technical Implementation Guide v1r2
 
 This profile was developed to reduce the time it takes to perform a security checks based upon the STIG Guidance from the Defense Information Systems Agency (DISA) in partnership between the DISA Services Directorate (SD) and the DISA Risk Management Executive (RME) office.

--- a/controls/SV-258094.rb
+++ b/controls/SV-258094.rb
@@ -25,12 +25,12 @@ Note: Manual changes to the listed file may be overwritten by the "authselect" p
 
   pam_auth_files = input('pam_auth_files')
   file_list = pam_auth_files.values.join(' ')
-  bad_entries = command("grep -i nullok #{file_list}").stdout.lines.collect(&:squish)
+  bad_entries = command("grep -i nullok #{file_list}").stdout.lines.map(&:strip)
 
-  describe 'The system is configureed' do
+  describe 'The system should be configureed' do
     subject { command("grep -i nullok #{file_list}") }
     it 'to not allow null passwords' do
-      expect(subject.stdout.strip).to be_empty, "The system is configured to allow null passwords. Please remove any instances of the `nullok` option from: \n\t- #{bad_entries.join("\n\t- ")}"
+      expect(subject.stdout.strip).to be_empty, "The system is configured to allow null passwords. Please remove any instances of the `nullok` option from auth files: \n\t- #{bad_entries.join("\n\t- ")}"
     end
   end
 end

--- a/inspec.yml
+++ b/inspec.yml
@@ -4,7 +4,7 @@ maintainer: MITRE SAF Team
 copyright: MITRE
 license: Apache-2.0
 summary: "InSpec profile aligned to DISA STIG for RHEL9"
-version: 1.2.1
+version: 1.2.2
 # NOTE: for testing with test-kitchen, put back to ">= 6.0" when finished
 inspec_version: ">= 5.0"
 


### PR DESCRIPTION
Reflecting [RHEL8 update](https://github.com/mitre/redhat-enterprise-linux-8-stig-baseline/pull/30) on RHEL9 for standardization.